### PR TITLE
Use https for creative commons link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,6 @@ Please read the [contribution guidelines](contributing.md) first.
 
 ## License
 
-[![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
+[![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Matias Singers](http://mts.io) has waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
I guess travis build is failing because the link for creative commons public domain page is being redirect from http to https. See it here https://travis-ci.org/matiassingers/awesome-readme/builds/164957006

So, I propose to change the link from http to https.
