### PR TITLE
Add Kodi to examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ Elements in beautiful READMEs include, but are not limited to: images, screensho
 - [thelounge/thelounge](https://github.com/thelounge/thelounge) - Project logo. Useful badges and links (website, docs, demo). Screenshot. Feature list. Step-by-step instructions for installation, development, and testing. Link to the contributing guide. Good mobile summary.
 - [vhesener/Closures](https://github.com/vhesener/Closures) - Project logo, cognitive funnel, animated examples. Color coordinated. Clean documentation.
 - [webpro/release-it](https://github.com/webpro/release-it) - Clear overview of project features with a demo GIF. Badges. Expandable TOC. Usage description and examples. Contribution guidelines. Detailed releases.
+- [xbmc/xbmc](https://github.com/xbmc/xbmc) - Project banner, multiple badges, clear description with GIF demo, contributing section and step-by-step compile guides, including coding guidelines, HOW-TOs, and a small git-fu reference guide.
 
 ## Articles
 


### PR DESCRIPTION
I think it is a worthy candidate but since I wrote most of it, my opinion is probably biased... 😛 

It extends far beyond the main **[README](https://github.com/xbmc/xbmc/blob/master/README.md)**, including

* **[index of compile guides and resources](https://github.com/xbmc/xbmc/blob/master/docs/README.md)**
* **[contributing guide](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)**
* **[code guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)**
* **[git-fu guide streamlined for our workflow](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)**

and a few HOW-TOs geared at C/C++ coders.

All documents have a TOC, `back to top` and `back to section top` links where appropriate. Full docs list can be seen **[here](https://github.com/xbmc/xbmc/tree/master/docs)**.

Thanks and keep up the great work!