### PR TITLE
Remove Joshua Holbrook's Article link (it now 404s)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,6 @@ Elements in beautiful READMEs include, but are not limited to: images, screensho
 
 - ["Art of Readme - Learn the art of writing quality READMEs."](https://github.com/noffle/art-of-readme) - *Stephen Whitmore*
 - ["How To Write A Great README"](https://robots.thoughtbot.com/how-to-write-a-great-readme) - *Caleb Thompson (thoughtbot)*
-- ["How To Write A Readme"](http://jfhbrook.github.io/2011/11/09/readmes.html) - *Joshua Holbrook*
 - ["Readme Driven Development"](http://tom.preston-werner.com/2010/08/23/readme-driven-development.html) - *Tom Preston-Werner*
 - ["Top ten reasons why I won’t use your open source project"](https://changelog.com/posts/top-ten-reasons-why-i-wont-use-your-open-source-project) - *Adam Stacoviak*
 - ["What I learned from an old GitHub project that won 3,000 Stars in a Week"](https://medium.freecodecamp.org/what-i-learned-from-an-old-github-project-that-won-3-000-stars-in-a-week-628349a5ee14) - *KyuWoo Choi*


### PR DESCRIPTION
The "How To Write A Readme" 404s, and a Google search indicates that
this page is now gone (not preserved in some other location).  Joshua
still has a github.io page (http://jfhbrook.github.io), but this
November 2011 article is not currently linked there.