### PR TITLE
Add GitHub Readme Stats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Elements in beautiful READMEs include, but are not limited to: images, screensho
 - [Amazing GitHub Template](https://github.com/dec0dOS/amazing-github-template#readme) - Useful README.md, LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, GitHub Issues, Pull Requests and Actions templates to jumpstart your projects.
 - [Common Readme](https://github.com/noffle/common-readme#readme) - A common readme style for Node. Includes a guide and a readme generator.
 - [Feedmereadmes](https://github.com/lappleapple/feedmereadmes#readme) - README editing and project analysis/feedback.
+- [GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats#readme) - Dynamically generated customizable GitHub cards for README. Stats, extra pins, top languages and WakaTime.
 - [Hall-of-fame](https://github.com/sourcerer-io/hall-of-fame#readme) - Helps show recognition to repo contributors on README. Features new/trending/top contributors. Updates every hour.
 - [Make a README](https://www.makeareadme.com/) - A guide to writing READMEs. Includes an editable template with live Markdown rendering.
 - [README best practices](https://github.com/jehna/readme-best-practices#readme) - A place to copy-paste your README.md from


### PR DESCRIPTION
[GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats#readme) is a widely know and used tool to complement READMEs with useful and highly customizable stats cards.

<details>
<summary>
Examples
</summary>
<p>

### GitHub stats card
[![GitHub stats card](https://camo.githubusercontent.com/8fd2570f103d1aae8a4d8970535274ae19c2ee62587d8868d618be37001263d0/68747470733a2f2f7265732e636c6f7564696e6172792e636f6d2f616e7572616768617a72612f696d6167652f75706c6f61642f76313539353137343533362f6772732d7468656d65735f6c34796e6a612e706e67)](https://github.com/anuraghazra/github-readme-stats)

### Extra pins card
[![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats)](https://github.com/anuraghazra/github-readme-stats)

### Top languages card
[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=correia-jpv)](https://github.com/anuraghazra/github-readme-stats)

### WakaTime card
[![user wakatime stats](https://github-readme-stats.vercel.app/api/wakatime?username=correiajpv)](https://github.com/anuraghazra/github-readme-stats)

</p>
</details>