### PR TITLE
Add link to kotlin-faker readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Elements in beautiful READMEs include, but are not limited to: images, screensho
 - [rstacruz/hicat](https://github.com/rstacruz/hicat#readme) - GIF demo. Easy installation and setup sections with screenshots. Build badges. Great examples of use cases.
 - [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts#readme) - Clean project logo. Brief description at top. Sankey diagram, quick links, badges, OS specific icons, TOC, detailed release changelog.
 - [sebyddd/SDVersion](https://github.com/sebyddd/SDVersion#readme) - Project logo. Build badges. Documentation structuring for multiple programming languages. Usage examples.
+- [serpro69/kotlin-faker](https://github.com/serpro69/kotlin-faker) - Porject logo. Badges. Concise description and clear getting-started instructions with a link to full ducomentation website. Test, build and contributing guidelines. Licence info.
 - [shama/gaze](https://github.com/shama/gaze#readme) - Project logo. Concise description. Feature list. Usage section. FAQ. Great API documentation. Release history.
 - [sidneycadot/oeis](https://github.com/sidneycadot/oeis#readme) - Overview. List of required dependencies. Complete list of all files in the repo and what their function is. Visual graph of how it all ties together.
 - [sindresorhus/pageres](https://github.com/sindresorhus/pageres#readme) - Project logo. Clear description of what the project does. Build badges. Demo screenshot. Simple install and usage sections. Includes an examples section with common uses.

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Elements in beautiful READMEs include, but are not limited to: images, screensho
 - [rstacruz/hicat](https://github.com/rstacruz/hicat#readme) - GIF demo. Easy installation and setup sections with screenshots. Build badges. Great examples of use cases.
 - [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts#readme) - Clean project logo. Brief description at top. Sankey diagram, quick links, badges, OS specific icons, TOC, detailed release changelog.
 - [sebyddd/SDVersion](https://github.com/sebyddd/SDVersion#readme) - Project logo. Build badges. Documentation structuring for multiple programming languages. Usage examples.
-- [serpro69/kotlin-faker](https://github.com/serpro69/kotlin-faker) - Project logo. Badges. Concise description and clear getting-started instructions with a link to full ducomentation website. Test, build and contributing guidelines. Licence info.
+- [serpro69/kotlin-faker](https://github.com/serpro69/kotlin-faker#readme) - Project logo. Badges. Concise description and clear getting-started instructions with a link to full ducomentation website. Test, build and contributing guidelines. Licence info.
 - [shama/gaze](https://github.com/shama/gaze#readme) - Project logo. Concise description. Feature list. Usage section. FAQ. Great API documentation. Release history.
 - [sidneycadot/oeis](https://github.com/sidneycadot/oeis#readme) - Overview. List of required dependencies. Complete list of all files in the repo and what their function is. Visual graph of how it all ties together.
 - [sindresorhus/pageres](https://github.com/sindresorhus/pageres#readme) - Project logo. Clear description of what the project does. Build badges. Demo screenshot. Simple install and usage sections. Includes an examples section with common uses.

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Elements in beautiful READMEs include, but are not limited to: images, screensho
 - [rstacruz/hicat](https://github.com/rstacruz/hicat#readme) - GIF demo. Easy installation and setup sections with screenshots. Build badges. Great examples of use cases.
 - [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts#readme) - Clean project logo. Brief description at top. Sankey diagram, quick links, badges, OS specific icons, TOC, detailed release changelog.
 - [sebyddd/SDVersion](https://github.com/sebyddd/SDVersion#readme) - Project logo. Build badges. Documentation structuring for multiple programming languages. Usage examples.
-- [serpro69/kotlin-faker](https://github.com/serpro69/kotlin-faker) - Porject logo. Badges. Concise description and clear getting-started instructions with a link to full ducomentation website. Test, build and contributing guidelines. Licence info.
+- [serpro69/kotlin-faker](https://github.com/serpro69/kotlin-faker) - Project logo. Badges. Concise description and clear getting-started instructions with a link to full ducomentation website. Test, build and contributing guidelines. Licence info.
 - [shama/gaze](https://github.com/shama/gaze#readme) - Project logo. Concise description. Feature list. Usage section. FAQ. Great API documentation. Release history.
 - [sidneycadot/oeis](https://github.com/sidneycadot/oeis#readme) - Overview. List of required dependencies. Complete list of all files in the repo and what their function is. Visual graph of how it all ties together.
 - [sindresorhus/pageres](https://github.com/sindresorhus/pageres#readme) - Project logo. Clear description of what the project does. Build badges. Demo screenshot. Simple install and usage sections. Includes an examples section with common uses.


### PR DESCRIPTION
Hi,

Would love to submit https://github.com/serpro69/kotlin-faker/blob/master/README.md to the list of examples.

I'm a believer in minimalistic approach when it comes to README contents because it's easier to consume, but at the same time think a readme should still be enough to "get started" with any given project. This is what I tried to achieve with the above readme, while also keeping it looking good.

Thanks for your consideration.