### PR TITLE
Add ft_transcendence to examples list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,6 @@ images, screenshots, GIFs, text formatting, etc.
 - [yvann-ba/ft_transcendence](https://github.com/yvann-ba/ft_transcendence#readme) - Minimalist Project banner, clear GIF gallery in table layout. Colorful architecture diagram. Clear tech stack description. Team section with contributor avatars.
 - [zenml-io/zenml](https://github.com/zenml-io/zenml#readme) - Clean project logo. Useful TOC. Clear code examples amongst the feature list. Quickstart example.
 
-
 ## Architecture Examples
 A good ARCHITECTURE.md file helps developers understand how and where to make changes, whether they are new to a project or not.
 

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,9 @@ images, screenshots, GIFs, text formatting, etc.
 - [themerdev/themer](https://github.com/themerdev/themer#readme) - Project logo. Visual description (flowchart) of what the project does. Build badges. TOC. Demo screenshot. Concise installation and usage sections, including common workflows. Colorful previews.
 - [vhesener/Closures](https://github.com/vhesener/Closures#readme) - Project logo, cognitive funnel, animated examples. Color-coordinated. Clean documentation.
 - [xnbox/DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP#readme) - Original hero section. Clear navigation. Minimalist design. Appendices.
+- [yvann-ba/ft_transcendence](https://github.com/yvann-ba/ft_transcendence#readme) - Minimalist Project banner, clear GIF gallery in table layout. Colorful architecture diagram. Clear tech stack description. Team section with contributor avatars.
 - [zenml-io/zenml](https://github.com/zenml-io/zenml#readme) - Clean project logo. Useful TOC. Clear code examples amongst the feature list. Quickstart example.
+
 
 ## Architecture Examples
 A good ARCHITECTURE.md file helps developers understand how and where to make changes, whether they are new to a project or not.


### PR DESCRIPTION
I've added my project ft_transcendence to the examples section of the README 

This project showcases:
-  GIF gallery in table format
- Clear Docker architecture diagram
- Team section with contributor avatars
- Colorful feature descriptions

I've placed it alphabetically as per the contributing guidelines.

Thank you for maintaining this awesome list, hope you're gonna like my README! ☝️🤓