### PR TITLE
add Telegram-Card

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,7 @@ This can also be a dedicated section of your README.md files.
 - [READMINE](https://github.com/mhucka/readmine) - A thorough, clear and self-describing README file template for software projects; copy it and edit it as needed.
 - [StackEdit](https://stackedit.io/) - A user-friendly online editor that allows you to quickly customize all the sections you need for your project's readme.
 - [Standard Readme](https://github.com/RichardLitt/standard-readme#readme) - A standard README style specification. Has a generator to help create spec-compliant READMEs, too.
+- [Telegram Card](https://github.com/Malith-Rukshan/telegram-card#readme) - Dynamic preview card generator for Telegram channels, groups, and bots. Features responsive design, dark/light theme support, and displays subscriber/member/monthly users/online users counts. Perfect for GitHub profiles and portfolios.
 - [user-statistician](https://github.com/cicirello/user-statistician) - A GitHub Action that generates SVG of detailed GitHub user activity for profile readmes. 
 - [Zalando's README Template](https://github.com/zalando/zalando-howto-open-source/blob/master/READMEtemplate.md#readme) - Simple template to help you cover all the basics.
 


### PR DESCRIPTION
I'd like to add my tool "Telegram Card" to the Tools section of Awesome README.

### Checklist:

- [x] My entry is alphabetized correctly
- [x] I searched for previous suggestions before making this one
- [x] The suggested README is beautiful or stands out
- [x] I made an individual pull request for this suggestion
- [x] The description is short, simple, but descriptive
- [x] The description starts with a capital and ends with a period
- [x] I checked my spelling and grammar
- [x] I used the `#readme` anchor for GitHub README link

| ![Preivew Item](https://telegram-card.vercel.app/?username=AlphaV2ray&theme=light) | ![Preivew Item](https://telegram-card.vercel.app/?username=SingleMusicX) |
|------------|-----------|
| ![Preivew Item](https://telegram-card.vercel.app/?username=MOD_APPS_Stock) | ![Preivew Item](https://telegram-card.vercel.app/?username=QuizUpLK) |
| ![Preivew Item](https://telegram-card.vercel.app/?username=ReceiveSMSRobot&theme=light) | ![Preivew Item](https://telegram-card.vercel.app/?username=Alpha_V2ray) |
![Telegram Channel](https://telegram-card.vercel.app/?username=durov&theme=dark) | ![Telegram Channel](https://telegram-card.vercel.app/?username=Premium&theme=dark)