### PR TITLE
Add Badges to Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,7 +138,6 @@ This can also be a dedicated section of your README.md files.
 - [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats#readme) - Dynamic SVG tables displaying your GitHub pull requests with dual modes: detailed PR list and repository aggregate statistics. Features status filtering, star-based sorting, and customizable fields.
 - [GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats#readme) - Dynamically generated customizable GitHub cards for README. Stats, extra pins, top languages and WakaTime.
 - [Badges](https://badges-jet.vercel.app/) - A serverless API and UI tool to create animated, auto-wrapping GitHub repository preview cards with custom logo and QR code support.
-- [Badges](https://badges-jet.vercel.app/) - A serverless API and UI tool to create animated, auto-wrapping GitHub repository preview cards with custom logo and QR code support.
 - [GPRM](https://github.com/VishwaGauravIn/github-profile-readme-maker) - A tool to generate a customized GitHub Profile README with a modern UI.
 - [Hall-of-fame](https://github.com/sourcerer-io/hall-of-fame#readme) - Helps show recognition to repo contributors on README. Features new/trending/top contributors. Updates every hour.
 - [Make a README](https://www.makeareadme.com/) - A guide to writing READMEs. Includes an editable template with live Markdown rendering.


### PR DESCRIPTION
Hello! I'm suggesting a new tool called **Badges** for the Tools section.

**Badges** is a serverless API and UI playground that allows developers to create animated, auto-wrapping preview cards for their GitHub repositories. 

Key features:
-  **Animated SVG:** Smooth entry animations for READMEs.
-  **Auto-wrapping:** Prevents layout breaks by wrapping badges to the next line.
-  **Custom Branding:** Support for project-specific logos and dynamic QR codes.
-  **Base64 Embedding:** Bypasses GitHub's Camo caching issues by embedding external assets directly.

I believe this would be a great addition for developers looking to spice up their repo headers!

<p align="center">
  <img src="https://badges-jet.vercel.app/api/card?username=matiassingers&repo=awesome-readme&theme=dark&animate=true&w=500&img=https://raw.githubusercontent.com/matiassingers/awesome-readme/master/icon.png&customBadges=List:Awesome:ff69b4:awesome-lists,Content:README:000000:github,Status:Curated:brightgreen" alt="Awesome README Card with Icon">
</p>