### PR TITLE
Add Docsmith — AI documentation generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,7 @@ This can also be a dedicated section of your README.md files.
 
 - [Amazing GitHub Template](https://github.com/dec0dOS/amazing-github-template#readme) - Useful README.md, LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, GitHub Issues, Pull Requests and Actions templates to jumpstart your projects.
 - [Common Readme](https://github.com/hackergrrl/common-readme#readme) - A common readme style for Node. Includes a guide and a readme generator.
+- [Docsmith](https://docsmithai.com?utm_source=github&utm_medium=awesome-list&utm_campaign=awesome-readme) - AI-powered tool that generates a complete documentation site from a GitHub repo URL in under 60 seconds. Markdown output, customizable theme, $19 one-time.
 - [Github Licenses Stats](https://github.com/lheintzmann1/github-licenses-stats#readme) - This tool generates a dynamic SVG that shows the top licenses used across your GitHub repositories.
 - [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats#readme) - Dynamic SVG tables displaying your GitHub pull requests with dual modes: detailed PR list and repository aggregate statistics. Features status filtering, star-based sorting, and customizable fields.
 - [GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats#readme) - Dynamically generated customizable GitHub cards for README. Stats, extra pins, top languages and WakaTime.


### PR DESCRIPTION
Adding Docsmith under Tools. Paste a GitHub repo URL, get a full docs site generated by Claude in ~60 seconds. Not a replacement for hand-crafted docs on mature projects, but solves the "no docs at all" problem for side-projects.