### PR TITLE
Add shieldcn to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,7 @@ This can also be a dedicated section of your README.md files.
 - [readme-md-generator](https://github.com/kefranabg/readme-md-generator#readme) - A CLI that generates beautiful README.md files
 - [README Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - Dynamically generated, customizable SVG that gives the appearance of typing and deleting text. Perfect for profile READMEs.
 - [READMINE](https://github.com/mhucka/readmine) - A thorough, clear and self-describing README file template for software projects; copy it and edit it as needed.
+- [shieldcn](https://shieldcn.com) - Shields.io alternative that renders README badges as shadcn/ui Button components via Satori. Supports npm, GitHub, Discord, and 40k+ icons with dark/light mode.
 - [StackEdit](https://stackedit.io/) - A user-friendly online editor that allows you to quickly customize all the sections you need for your project's readme.
 - [Standard Readme](https://github.com/RichardLitt/standard-readme#readme) - A standard README style specification. Has a generator to help create spec-compliant READMEs, too.
 - [Telegram Card](https://github.com/Malith-Rukshan/telegram-card#readme) - Dynamic preview card generator for Telegram channels, groups, and bots. Features responsive design, dark/light theme support, and displays subscriber/member/monthly users/online users counts. Perfect for GitHub profiles and portfolios.


### PR DESCRIPTION
[shieldcn](https://shieldcn.com) is a shields.io alternative that renders README badges as shadcn/ui Button components via Satori. It generates beautiful, styled SVG/PNG badge images for use in GitHub READMEs, npm pages, and documentation sites.

Supports npm, GitHub, Discord, Reddit, and static badges with dark/light mode, multiple variants, and 40,000+ icons from SimpleIcons, Lucide, and React Icons.

**GitHub:** https://github.com/jal-co/shieldcn

- [x] Tool is aimed at project readmes, not profile readmes.
- [x] Alphabetized entry (placed before StackEdit).
- [x] Searched previous suggestions — no duplicate found.
- [x] Description starts with a capital, ends with a full stop/period.
- [x] Links are active and not broken.