### PR TITLE
Add Commitment Issues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ This can also be a dedicated section of your README.md files.
 - [Telegram Card](https://github.com/Malith-Rukshan/telegram-card#readme) - Dynamic preview card generator for Telegram channels, groups, and bots. Features responsive design, dark/light theme support, and displays subscriber/member/monthly users/online users counts. Perfect for GitHub profiles and portfolios.
 - [user-statistician](https://github.com/cicirello/user-statistician) - A GitHub Action that generates SVG of detailed GitHub user activity for profile readmes. 
 - [Zalando's README Template](https://github.com/zalando/zalando-howto-open-source/blob/master/READMEtemplate.md#readme) - Simple template to help you cover all the basics.
+- [Commitment Issues](https://github.com/dotsystemsdevs/commitmentissues) - Free open-source web app that issues a satirical "death certificate" for abandoned GitHub repos — algorithmic cause of death, last commit as last words, severity score, profile graveyard scan.
 
 ## Creating GIFs
 


### PR DESCRIPTION
Adding **Commitment Issues** to matiassingers/awesome-readme.

### What it does
Free open-source web app that issues a satirical "death certificate" for abandoned GitHub repos — algorithmic cause of death, last commit as last words, severity score, profile graveyard scan.

### Why it fits
- Free, open source (MIT), no signup, no ads
- Useful for developers vetting dependencies or cleaning up bookmarks
- Live at https://commitmentissues.dev, source at https://github.com/dotsystemsdevs/commitmentissues

Thanks for maintaining this list 🦥