### PR TITLE
Add yeaight7/awesome-ai-devtools to examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ images, screenshots, GIFs, text formatting, etc.
 - [vhesener/Closures](https://github.com/vhesener/Closures#readme) - Project logo, cognitive funnel, animated examples. Color-coordinated. Clean documentation.
 - [voltagent/voltagent](https://github.com/voltagent/voltagent#readme) - Clean project logo. Useful badges and links (website, docs, demo). Screenshot. Clear code examples amongst the feature list. Quickstart example.
 - [xnbox/DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP#readme) - Original hero section. Clear navigation. Minimalist design. Appendices.
-- [yeaight7/yeaight7](https://github.com/yeaight7/yeaight7#readme) - Animated signal-board aesthetic with custom SVG panels, live telemetry cards, collapsible sections, and featured project spotlights.
+- [yeaight7/awesome-ai-devtools](https://github.com/yeaight7/awesome-ai-devtools#readme) - Custom SVG header, polished storefront layout, shelf-based navigation, comparison matrix, and review-backed metadata summaries.
 - [yvann-ba/ft_transcendence](https://github.com/yvann-ba/ft_transcendence#readme) - Minimalist Project banner, clear GIF gallery in table layout. Colorful architecture diagram. Clear tech stack description. Team section with contributor avatars.
 - [zenml-io/zenml](https://github.com/zenml-io/zenml#readme) - Clean project logo. Useful TOC. Clear code examples amongst the feature list. Quickstart example.
 

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ images, screenshots, GIFs, text formatting, etc.
 - [vhesener/Closures](https://github.com/vhesener/Closures#readme) - Project logo, cognitive funnel, animated examples. Color-coordinated. Clean documentation.
 - [voltagent/voltagent](https://github.com/voltagent/voltagent#readme) - Clean project logo. Useful badges and links (website, docs, demo). Screenshot. Clear code examples amongst the feature list. Quickstart example.
 - [xnbox/DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP#readme) - Original hero section. Clear navigation. Minimalist design. Appendices.
-- [yeaight7/awesome-ai-devtools](https://github.com/yeaight7/awesome-ai-devtools#readme) - Custom SVG header, polished storefront layout, shelf-based navigation, comparison matrix, and review-backed metadata summaries.
+- [yeaight7/awesome-ai-devtools](https://github.com/yeaight7/awesome-ai-devtools#readme) - Auto-Generated README built from structured metadata, with a custom SVG header, comparison matrix, category index, tool tables, and review-backed summaries.
 - [yvann-ba/ft_transcendence](https://github.com/yvann-ba/ft_transcendence#readme) - Minimalist Project banner, clear GIF gallery in table layout. Colorful architecture diagram. Clear tech stack description. Team section with contributor avatars.
 - [zenml-io/zenml](https://github.com/zenml-io/zenml#readme) - Clean project logo. Useful TOC. Clear code examples amongst the feature list. Quickstart example.
 

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,7 @@ images, screenshots, GIFs, text formatting, etc.
 - [vhesener/Closures](https://github.com/vhesener/Closures#readme) - Project logo, cognitive funnel, animated examples. Color-coordinated. Clean documentation.
 - [voltagent/voltagent](https://github.com/voltagent/voltagent#readme) - Clean project logo. Useful badges and links (website, docs, demo). Screenshot. Clear code examples amongst the feature list. Quickstart example.
 - [xnbox/DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP#readme) - Original hero section. Clear navigation. Minimalist design. Appendices.
+- [yeaight7/yeaight7](https://github.com/yeaight7/yeaight7#readme) - Animated signal-board aesthetic with custom SVG panels, live telemetry cards, collapsible sections, and featured project spotlights.
 - [yvann-ba/ft_transcendence](https://github.com/yvann-ba/ft_transcendence#readme) - Minimalist Project banner, clear GIF gallery in table layout. Colorful architecture diagram. Clear tech stack description. Team section with contributor avatars.
 - [zenml-io/zenml](https://github.com/zenml-io/zenml#readme) - Clean project logo. Useful TOC. Clear code examples amongst the feature list. Quickstart example.
 


### PR DESCRIPTION
## Summary

I would like to suggest [`yeaight7/awesome-ai-devtools`](https://github.com/yeaight7/awesome-ai-devtools#readme) for the examples list.

## Why this README stands out
* Generated from structured metadata instead of being edited manually.
* Clear visual header and top section that explain the project quickly.
* Featured entries near the top for several different categories.
* Comparison matrix that helps readers compare selected tools at a glance.
* Category index that makes a long README easier to browse.
* Category-based tables with consistent metadata such as name, description, best use, interface, and links.
* New arrivals and draft/review-required sections that separate verified entries from entries still being reviewed.
* Counts, category summaries, tables, and generated sections update automatically as the catalog changes.

## Fit with this list

- It is a project README, not a profile README.
- The entry uses the `#readme` anchor.
- The description in the list is short and factual.

## Images

<img width="1200" height="400" alt="awesome-ai-devtools-header" src="https://github.com/user-attachments/assets/b1a37f50-85d7-45ff-a8e5-0126d2220158" />


<img width="840" height="1078" alt="Captura de pantalla 2026-05-21 171959" src="https://github.com/user-attachments/assets/838b0388-44b1-4fd0-9cef-30ba4fcccbfa" />

<img width="1280" height="640" alt="awesome-ai-devtools-social-preview" src="https://github.com/user-attachments/assets/ddf1a68c-3739-4694-812f-4796b879df45" />
