### PR TITLE
Add Daily Badge to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,7 @@ This can also be a dedicated section of your README.md files.
 
 - [Amazing GitHub Template](https://github.com/dec0dOS/amazing-github-template#readme) - Useful README.md, LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, GitHub Issues, Pull Requests and Actions templates to jumpstart your projects.
 - [Common Readme](https://github.com/hackergrrl/common-readme#readme) - A common readme style for Node. Includes a guide and a readme generator.
+- [Daily Badge](https://github.com/in-c0/daily-badge#readme) - A dynamically generated badge that shows a new quirky "on this day" message on your profile each day, in your own timezone.
 - [Github Licenses Stats](https://github.com/lheintzmann1/github-licenses-stats#readme) - This tool generates a dynamic SVG that shows the top licenses used across your GitHub repositories.
 - [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats#readme) - Dynamic SVG tables displaying your GitHub pull requests with dual modes: detailed PR list and repository aggregate statistics. Features status filtering, star-based sorting, and customizable fields.
 - [GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats#readme) - Dynamically generated customizable GitHub cards for README. Stats, extra pins, top languages and WakaTime.


### PR DESCRIPTION
Adds **Daily Badge** to the Tools section (alphabetically, between *Common Readme* and *Github Licenses Stats*).

It's a dynamically generated SVG badge — like *README Typing SVG* and *user-statistician* already in this section — that shows a new quirky "on this day" message on your profile each day, rendered in your own timezone. Zero setup: a single URL, no fork or Actions cron.

- Live customizer: https://in-c0.github.io/daily-badge/
- Example: `https://daily-badge.wldud5192.workers.dev/badge.svg?tz=Australia/Sydney`

Single-line addition, sentence-case description ending in a period to satisfy awesome-lint. Thanks! 🙏