### PR TITLE
Add github-pet to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,7 @@ This can also be a dedicated section of your README.md files.
 - [Github Licenses Stats](https://github.com/lheintzmann1/github-licenses-stats#readme) - This tool generates a dynamic SVG that shows the top licenses used across your GitHub repositories.
 - [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats#readme) - Dynamic SVG tables displaying your GitHub pull requests with dual modes: detailed PR list and repository aggregate statistics. Features status filtering, star-based sorting, and customizable fields.
 - [GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats#readme) - Dynamically generated customizable GitHub cards for README. Stats, extra pins, top languages and WakaTime.
+- [github-pet](https://github.com/prsdx/github-pet#readme) - Animated pixel cat for your GitHub profile README that reacts to real activity (CI failures, streaks, releases). Zero-dependency SVGs via a GitHub Action.
 - [GPRM](https://github.com/VishwaGauravIn/github-profile-readme-maker#readme) - A tool to generate a customized GitHub Profile README with a modern UI.
 - [Hall-of-fame](https://github.com/sourcerer-io/hall-of-fame#readme) - Helps show recognition to repo contributors on README. Features new/trending/top contributors. Updates every hour.
 - [Make a README](https://www.makeareadme.com/) - A guide to writing READMEs. Includes an editable template with live Markdown rendering.


### PR DESCRIPTION
github-pet is a zero-dependency pixel cat for GitHub profile READMEs that reacts to real activity: CI failures (overheat), contribution streaks (campfire), releases (trophy), day/night sky, isometric contribution city, mood badge. Ships as a GitHub Action (uses: prsdx/github-pet@v1); SVGs regenerate every 6h in the adopter repo. MIT licensed, live demo on the author profile.