### PR TITLE
Add GitHub README Insight Terminal ASCII to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ This can also be a dedicated section of your README.md files.
 - [Common Readme](https://github.com/hackergrrl/common-readme#readme) - A common readme style for Node. Includes a guide and a readme generator.
 - [Github Licenses Stats](https://github.com/lheintzmann1/github-licenses-stats#readme) - This tool generates a dynamic SVG that shows the top licenses used across your GitHub repositories.
 - [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats#readme) - Dynamic SVG tables displaying your GitHub pull requests with dual modes: detailed PR list and repository aggregate statistics. Features status filtering, star-based sorting, and customizable fields.
+- [GitHub README Insight Terminal ASCII](https://github.com/seuthootDev/github-readme-insight-terminal-ascii#readme) - Terminal-styled SVG cards (contribution graph, stats, top languages, neofetch) for your GitHub README, themed as macOS/Windows/Ubuntu terminals.
 - [GitHub Readme Stats](https://github.com/anuraghazra/github-readme-stats#readme) - Dynamically generated customizable GitHub cards for README. Stats, extra pins, top languages and WakaTime.
 - [GPRM](https://github.com/VishwaGauravIn/github-profile-readme-maker#readme) - A tool to generate a customized GitHub Profile README with a modern UI.
 - [Hall-of-fame](https://github.com/sourcerer-io/hall-of-fame#readme) - Helps show recognition to repo contributors on README. Features new/trending/top contributors. Updates every hour.


### PR DESCRIPTION
Adds [GitHub README Insight Terminal ASCII](https://github.com/seuthootDev/github-readme-insight-terminal-ascii) to the Tools section.

Generates terminal-styled SVG cards for GitHub profile READMEs — contribution graph, stats, top languages, and a GitHub neofetch card — themed as macOS / Windows PowerShell / Ubuntu terminals.